### PR TITLE
Add requests verify option to api instance

### DIFF
--- a/transmart/api/v1/api.py
+++ b/transmart/api/v1/api.py
@@ -30,7 +30,7 @@ class TransmartV1:
     """ Connect to tranSMART V1 api using Python. """
 
     def __init__(self, host, user=None, password=None, kc_url=None,
-                 kc_realm=None, client_id=None, print_urls=False, *args, **kwargs):
+                 kc_realm=None, client_id=None, print_urls=False, verify=None, *args, **kwargs):
         """
         Create the python transmart client by providing user credentials.
 
@@ -41,9 +41,13 @@ class TransmartV1:
         :param kc_realm: Realm that is registered for the transmart api host to listen.
         :param client_id: client id in keycloak.
         :param print_urls: print the url of handles being used.
+        :param verify: Either a boolean, in which case it controls whether we verify
+        the server’s TLS certificate, or a string, in which case it must be a path
+        to a CA bundle to use. Defaults to True.
         """
         self.host = host
         self.print_urls = print_urls
+        self.verify = verify
         self.auth = get_auth(host, user, password, kc_url, kc_realm, client_id)
 
     def get_observations(self, study=None, patientSet=None, as_dataframe=True, hal=False):
@@ -134,7 +138,7 @@ class TransmartV1:
         headers['Accept'] = 'application/%s;charset=UTF-8' % ('hal+json' if hal else 'json')
         if self.auth.access_token is not None:
             headers['Authorization'] = 'Bearer ' + self.auth.access_token
-        r = requests.post(url, headers=headers)
+        r = requests.post(url, headers=headers, verify=self.verify)
         r.raise_for_status()
         return r.json()
 
@@ -149,7 +153,7 @@ class TransmartV1:
         if self.auth.access_token is not None:
             headers['Authorization'] = 'Bearer ' + self.auth.access_token
 
-        r = requests.get(url, headers=headers)
+        r = requests.get(url, headers=headers, verify=self.verify)
         r.raise_for_status()
         return r.json()
 

--- a/transmart/api/v2/api.py
+++ b/transmart/api/v2/api.py
@@ -4,14 +4,14 @@
 * version 3.
 """
 
-import transmart
-
 import logging
 from functools import wraps
 from json import JSONDecodeError
 from urllib.parse import unquote_plus
 
 import requests
+
+import transmart
 from ..auth import get_auth
 
 if transmart.dependency_mode == 'FULL':
@@ -65,7 +65,8 @@ class Query:
 class TransmartV2:
     """ Connect to tranSMART v2 API using Python. """
 
-    def __init__(self, host, user=None, password=None, kc_url=None, kc_realm=None, client_id=None, print_urls=False, interactive=True):
+    def __init__(self, host, user=None, password=None, kc_url=None, kc_realm=None,
+                 client_id=None, print_urls=False, interactive=True, verify=None):
         """
         Create the python transmart client by providing user credentials.
 
@@ -77,6 +78,9 @@ class TransmartV2:
         :param print_urls: print the url of handles being used.
         :param interactive: automatically build caches for interactive use.
         :param client_id: client id in keycloak.
+        :param verify: Either a boolean, in which case it controls whether we verify
+        the server’s TLS certificate, or a string, in which case it must be a path
+        to a CA bundle to use. Defaults to True.
         """
         self.studies = None
         self.tree_dict = None
@@ -85,6 +89,7 @@ class TransmartV2:
         self.host = host
         self.interactive = interactive
         self.print_urls = print_urls
+        self.verify = verify
 
         self.auth = get_auth(host, user, password, kc_url, kc_realm, client_id)
 
@@ -123,9 +128,9 @@ class TransmartV2:
         headers['Authorization'] = 'Bearer ' + self.auth.access_token
 
         if q.method.upper() == 'GET':
-            r = requests.get(url, params=q.params, headers=headers)
+            r = requests.get(url, params=q.params, headers=headers, verify=self.verify)
         else:
-            r = requests.post(url, json=q.json, params=q.params, headers=headers)
+            r = requests.post(url, json=q.json, params=q.params, headers=headers, verify=self.verify)
 
         if self.print_urls:
             print(unquote_plus(r.url))

--- a/transmart/main.py
+++ b/transmart/main.py
@@ -3,7 +3,8 @@ from .api.v2.api import TransmartV2
 
 
 def get_api(host, api_version=2, user=None, password=None, kc_url=None,
-            kc_realm=None, print_urls=False, interactive=True, client_id=None, **kwargs):
+            kc_realm=None, print_urls=False, interactive=True, client_id=None,
+            verify=None, **kwargs):
     """
     Create the python transmart client by providing user credentials.
 
@@ -16,6 +17,9 @@ def get_api(host, api_version=2, user=None, password=None, kc_url=None,
     :param print_urls: print the url of handles being used.
     :param interactive: automatically build caches for interactive use.
     :param client_id: client id in keycloak.
+    :param verify: Either a boolean, in which case it controls whether we verify
+    the server’s TLS certificate, or a string, in which case it must be a path
+    to a CA bundle to use. Defaults to True.
     """
     api_versions = (1, 2)
 
@@ -32,4 +36,5 @@ def get_api(host, api_version=2, user=None, password=None, kc_url=None,
                print_urls=print_urls,
                interactive=interactive,
                client_id=client_id,
+               verify=verify,
                **kwargs)


### PR DESCRIPTION
Allows the python-client to be used with a local instance of transmart. 
Either by turning verification off or providing a path to a self-signed certificate.

Default behavior remains unchanged.
